### PR TITLE
Verification that an element is not covered by some other element

### DIFF
--- a/jfunk-web/src/main/java/com/mgmtp/jfunk/web/WebConstants.java
+++ b/jfunk-web/src/main/java/com/mgmtp/jfunk/web/WebConstants.java
@@ -68,6 +68,11 @@ public final class WebConstants {
 	public static final String WEBDRIVER_DONT_QUIT = "webdriver.dont.quit";
 
 	/*
+	 * Properties for WebDriverTools
+	 */
+	public static final String WDT_TOPMOST_ELEMENT_CHECK = "wdt.topmostElementCheck";
+
+	/*
 	 * Properties for the default WebElementFinder
 	 */
 	public static final String WEF_ENABLED = "wef.enabled";

--- a/jfunk-web/src/main/java/com/mgmtp/jfunk/web/util/Rectangle.java
+++ b/jfunk-web/src/main/java/com/mgmtp/jfunk/web/util/Rectangle.java
@@ -17,6 +17,7 @@ package com.mgmtp.jfunk.web.util;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openqa.selenium.Point;
 
 /**
  * @author rnaegele
@@ -31,6 +32,36 @@ public class Rectangle {
 		this.right = right;
 		this.width = width;
 		this.height = height;
+	}
+
+	/**
+	 * Returns the point that specifies the center of the rectangle.
+	 *
+	 * @return center of the rectangle.
+	 */
+	public Point center() {
+		return new Point(left + width / 2, top + height / 2);
+	}
+
+	/**
+	 * Returns the intersection with the other rectangle or null if the two rectangles do not intersect.
+	 *
+	 * @param other the other rectangle.
+	 *
+	 * @return intersection rectangle or null.
+	 */
+	public Rectangle intersection(Rectangle other) {
+		int left = Math.max(this.left, other.left);
+		int top = Math.max(this.top, other.top);
+		int right = Math.min(this.right, other.right);
+		int bottom = Math.min(this.bottom, other.bottom);
+		if (right >= left && bottom >= top) {
+			int height = bottom - top;
+			int width = right - left;
+			return new Rectangle(top, left, bottom, right, width, height);
+		} else {
+			return null;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
When using WebDriver to perform certain actions (e.g., click) on elements which are covered by some other elements, the action may succeed even if it would fail, if performed manually by the user.

This pull request introduces a new property "wdt.topmostElementCheck" (in script.properties) and adds support to WebDriverTool for verification that an element is not covered by some other element.
